### PR TITLE
Task 6 - Fix the messages controller

### DIFF
--- a/app/Http/Controllers/Api/MessageController.php
+++ b/app/Http/Controllers/Api/MessageController.php
@@ -57,9 +57,21 @@ class MessageController extends Controller
     public function store(Request $request)
     {
         $this->validate($request, [
+            'parent_id' => 'required',
             'topic_id' => 'required',
             'body' => 'required',
         ]);
+
+        // get topic id for a give parent id
+        $message = Message::where('id', $request->parent_id)->first();
+
+        if($message->topic_id != $request->topic_id) {
+            return response()->json([
+                'error' => [
+                    'message' => "Cannot link a message to a parent_id that doesn't share the same topic_id",
+                ]
+            ]);
+        }
 
         return Message::create($request->all());
     }

--- a/tests/Feature/Api/MessageRequestTest.php
+++ b/tests/Feature/Api/MessageRequestTest.php
@@ -16,4 +16,17 @@ class MessageRequestTest extends TestCase
         $this->assertArrayHasKey('created_at', $request);
         $this->assertArrayHasKey('updated_at', $request);
      }
+
+     /** @test */
+     public function creating_a_message_with_parent_id_that_belongs_to_a_different_topic_id_must_return_an_error() {
+        $request = $this->json('POST', 'api/v1/messages', [
+                // values based on sample test case in local env
+                'topic_id'  => 21,
+                'parent_id' => 4,
+                'user_id'   => 1,
+                'body'      => "lorem ipsum dolor sit amet"
+        ])->decodeResponseJson();
+
+        $this->assertArrayHasKey('error', $request);
+     }
 }


### PR DESCRIPTION
## Task 6 - Fix the messages controller
- Added validation in MessageController@store to only allow storing
  based on given criteria
- Created php unit test to check the given criteria